### PR TITLE
Tickets/dm 2701

### DIFF
--- a/tests/DbStorage_1.cc
+++ b/tests/DbStorage_1.cc
@@ -30,6 +30,7 @@
 #include <sys/time.h>
 #include "lsst/daf/persistence/DbStorage.h"
 #include "lsst/daf/persistence/LogicalLocation.h"
+#include "lsst/daf/persistence/DbAuth.h"
 #include "lsst/pex/exceptions.h"
 
 #define BOOST_TEST_MODULE DbStorage_1
@@ -43,6 +44,14 @@ BOOST_AUTO_TEST_SUITE(DbStorageSuite)
 
 BOOST_AUTO_TEST_CASE(DbStorage) {
     lsst::pex::policy::Policy::Ptr policy(new lsst::pex::policy::Policy);
+
+    //If the user cannot access the test database, exit
+    //without failing
+    dafPersist::DbAuth testAuth;
+    testAuth.setPolicy(policy);
+    if(!testAuth.available("lsst10.ncsa.uiuc.edu","3306")){
+        return;
+    }
 
     struct timeval tv;
     gettimeofday(&tv, 0); 
@@ -135,6 +144,14 @@ BOOST_AUTO_TEST_CASE(DbStorage) {
 
 BOOST_AUTO_TEST_CASE(DbStorageExprs) {
     lsst::pex::policy::Policy::Ptr policy(new lsst::pex::policy::Policy);
+
+    //If the user cannot access the test database, exit
+    //without failing
+    dafPersist::DbAuth testAuth;
+    testAuth.setPolicy(policy);
+    if(!testAuth.available("lsst10.ncsa.uiuc.edu","3306")){
+        return;
+    }
 
     // Normally, we would create a DbStorage via
     // Persistence::getRetrieveStorage().  For testing purposes, we create one

--- a/tests/Persistence_1.cc
+++ b/tests/Persistence_1.cc
@@ -32,6 +32,7 @@ extern "C" {
 #include "lsst/daf/persistence/DbTsvStorage.h"
 #include "lsst/daf/persistence/Formatter.h"
 #include "lsst/daf/persistence/LogicalLocation.h"
+#include "lsst/daf/persistence/DbAuth.h"
 #include "lsst/daf/persistence/Persistence.h"
 
 #define BOOST_TEST_MODULE Persistence_1
@@ -184,6 +185,14 @@ BOOST_AUTO_TEST_SUITE(PersistenceSuite)
 BOOST_AUTO_TEST_CASE(PersistenceTest) {
     // Define a blank Policy.
     lsst::pex::policy::Policy::Ptr policy(new lsst::pex::policy::Policy);
+
+    //If the user cannot access the test database, exit
+    //without failing
+    dafPersist::DbAuth testAuth;
+    testAuth.setPolicy(policy);
+    if(!testAuth.available("lsst10.ncsa.uiuc.edu","3306")){
+        return;
+    }
 
     // Get a unique id for this test.
     struct timeval tv;

--- a/tests/Persistence_2.cc
+++ b/tests/Persistence_2.cc
@@ -33,6 +33,7 @@
 #include "lsst/daf/persistence/DbStorage.h"
 #include "lsst/daf/persistence/Formatter.h"
 #include "lsst/daf/persistence/LogicalLocation.h"
+#include "lsst/daf/persistence/DbAuth.h"
 #include "lsst/daf/persistence/Persistence.h"
 
 #define BOOST_TEST_MODULE Persistence_2
@@ -191,6 +192,14 @@ BOOST_AUTO_TEST_SUITE(Persistence2Suite)
 BOOST_AUTO_TEST_CASE(Persistence2Test) {
     // Define a blank Policy.
     lsst::pex::policy::Policy::Ptr policy(new lsst::pex::policy::Policy);
+
+    //If the user cannot access the test database, exit
+    //without failing
+    dafPersist::DbAuth testAuth;
+    testAuth.setPolicy(policy);
+    if(!testAuth.available("lsst10.ncsa.uiuc.edu","3306")){
+        return;
+    }
 
     // Get a unique id for this test.
     struct timeval tv;

--- a/tests/Persistence_2.py
+++ b/tests/Persistence_2.py
@@ -20,9 +20,14 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
+import sys
 import lsst.daf.base as dafBase
 import lsst.daf.persistence as dafPersist
 import lsst.pex.policy as pexPolicy
+
+if not dafPersist.DbAuth.available("lsst10.ncsa.uiuc.edu", "3306"):
+    print "*** WARNING*** Database authenticator unavailable.  Skipping test."
+    sys.exit()
 
 def test1():
     """

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -3,10 +3,5 @@ from lsst.sconsUtils import scripts
 import os
 
 ignoreList = ["cameraMapper.py", "pickleMapper.py"]
-if not os.path.exists(os.path.join(os.environ['HOME'], ".lsst/db-auth.paf")):
-    ignoreList.extend(["DateTime_1", "DbStorage_1", "DbStorage_1.py", "DbStorage_2.py",
-                       "Persistence_1", "Persistence_2", "Persistence_2.py"])
-    print "WARNING: No fallback database authenticator seen"
-    print "Database tests are being skipped"
 
 scripts.BasicSConscript.tests(ignoreList=ignoreList)

--- a/ups/daf_persistence.table
+++ b/ups/daf_persistence.table
@@ -2,7 +2,7 @@ setupRequired(mysqlclient)
 setupRequired(pex_logging)
 setupRequired(pex_policy)
 
-envAppend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
-envAppend(DYLD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
+envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
+envPrepend(DYLD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
 
-envAppend(PYTHONPATH, ${PRODUCT_DIR}/python)
+envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
The unit tests were failing if the user had a .lsst/db-auth.paf file without the correct credentials.  This is because unit tests were skipped based on whether or not .lsst/db-auth.paf existed, without regards to its contents.  This skip was implemented in the tests/SConscript file.  This pull requests moves the skipping determination into the actual unit tests themselves, and makes the decision whether or not to skip a test based on both the contents and the existence of .lsst/db-auth.paf.