### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/daf/persistence/BoostStorage.h
+++ b/include/lsst/daf/persistence/BoostStorage.h
@@ -44,13 +44,13 @@
   */
 
 
+#include <fstream>
+#include <memory>
+
 #include "lsst/daf/persistence/Storage.h"
 
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
-
-#include <memory>
-#include <fstream>
 
 namespace lsst {
 namespace daf {

--- a/include/lsst/daf/persistence/BoostStorage.h
+++ b/include/lsst/daf/persistence/BoostStorage.h
@@ -48,6 +48,7 @@
 
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
+
 #include <memory>
 #include <fstream>
 

--- a/include/lsst/daf/persistence/BoostStorage.h
+++ b/include/lsst/daf/persistence/BoostStorage.h
@@ -73,11 +73,11 @@ public:
     virtual boost::archive::text_iarchive& getIArchive(void);
 
 private:
-    boost::scoped_ptr<std::ofstream> _ostream; ///< Output stream.
-    boost::scoped_ptr<std::ifstream> _istream; ///< Input stream.
-    boost::scoped_ptr<boost::archive::text_oarchive> _oarchive;
+    std::unique_ptr<std::ofstream> _ostream; ///< Output stream.
+    std::unique_ptr<std::ifstream> _istream; ///< Input stream.
+    std::unique_ptr<boost::archive::text_oarchive> _oarchive;
         ///< boost::serialization archive wrapper for output stream.
-    boost::scoped_ptr<boost::archive::text_iarchive> _iarchive;
+    std::unique_ptr<boost::archive::text_iarchive> _iarchive;
         ///< boost::serialization archive wrapper for input stream.
 };
 

--- a/include/lsst/daf/persistence/BoostStorage.h
+++ b/include/lsst/daf/persistence/BoostStorage.h
@@ -48,7 +48,7 @@
 
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <fstream>
 
 namespace lsst {
@@ -57,7 +57,7 @@ namespace persistence {
 
 class BoostStorage : public Storage {
 public:
-    typedef boost::shared_ptr<BoostStorage> Ptr;
+    typedef std::shared_ptr<BoostStorage> Ptr;
 
     BoostStorage(void);
     virtual ~BoostStorage(void);

--- a/include/lsst/daf/persistence/DbStorage.h
+++ b/include/lsst/daf/persistence/DbStorage.h
@@ -50,7 +50,7 @@
 
 #include <string>
 #include <vector>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace lsst {
 namespace daf {
@@ -62,7 +62,7 @@ class DbStorageLocation;
 
 class DbStorage : public Storage {
 public:
-    typedef boost::shared_ptr<DbStorage> Ptr;
+    typedef std::shared_ptr<DbStorage> Ptr;
 
     DbStorage(void);
     ~DbStorage(void);

--- a/include/lsst/daf/persistence/DbStorage.h
+++ b/include/lsst/daf/persistence/DbStorage.h
@@ -110,7 +110,7 @@ protected:
     explicit DbStorage(std::type_info const& type);
 
 private:
-    boost::scoped_ptr<DbStorageImpl> _impl;
+    std::unique_ptr<DbStorageImpl> _impl;
         ///< Implementation class for isolation.
 };
 

--- a/include/lsst/daf/persistence/DbStorageLocation.h
+++ b/include/lsst/daf/persistence/DbStorageLocation.h
@@ -45,7 +45,7 @@
   * @ingroup daf_persistence
   */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 #include "lsst/daf/base/Citizen.h"
@@ -57,7 +57,7 @@ namespace persistence {
 
 class DbStorageLocation : public lsst::daf::base::Citizen {
 public:
-    typedef boost::shared_ptr<DbStorageLocation> Ptr;
+    typedef std::shared_ptr<DbStorageLocation> Ptr;
 
     DbStorageLocation(void);
     DbStorageLocation(std::string const& url);

--- a/include/lsst/daf/persistence/DbTsvStorage.h
+++ b/include/lsst/daf/persistence/DbTsvStorage.h
@@ -106,7 +106,7 @@ private:
     std::map<std::string, int> _colMap; ///< Map from column names to positions.
     std::ostringstream _convertStream;  ///< Stream to convert to text.
     std::vector<std::string> _rowBuffer;
-    boost::scoped_ptr<std::ofstream> _osp;  ///< Output TSV stream.
+    std::unique_ptr<std::ofstream> _osp;  ///< Output TSV stream.
 
     int _getColumnIndex(std::string const& columnName);
 };

--- a/include/lsst/daf/persistence/DbTsvStorage.h
+++ b/include/lsst/daf/persistence/DbTsvStorage.h
@@ -50,7 +50,7 @@
 
 #include "lsst/daf/persistence/DbStorage.h"
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <fstream>
 #include <map>
 #include <sstream>
@@ -65,7 +65,7 @@ namespace persistence {
 
 class DbTsvStorage : public DbStorage {
 public:
-    typedef boost::shared_ptr<DbTsvStorage> Ptr;
+    typedef std::shared_ptr<DbTsvStorage> Ptr;
 
     DbTsvStorage(void);
     ~DbTsvStorage(void);

--- a/include/lsst/daf/persistence/FitsStorage.h
+++ b/include/lsst/daf/persistence/FitsStorage.h
@@ -51,7 +51,7 @@ namespace persistence {
 
 class FitsStorage : public Storage {
 public:
-    typedef boost::shared_ptr<FitsStorage> Ptr;
+    typedef std::shared_ptr<FitsStorage> Ptr;
 
     FitsStorage(void);
     virtual ~FitsStorage(void);

--- a/include/lsst/daf/persistence/Formatter.h
+++ b/include/lsst/daf/persistence/Formatter.h
@@ -53,7 +53,7 @@
   * @ingroup daf_persistence
   */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 #include <typeinfo>
 
@@ -78,7 +78,7 @@ class LogicalLocation;
 
 class Formatter : public lsst::daf::base::Citizen {
 public:
-    typedef boost::shared_ptr<Formatter> Ptr;
+    typedef std::shared_ptr<Formatter> Ptr;
 
     /** Pointer to a (static) factory function for a Formatter subclass.
       */

--- a/include/lsst/daf/persistence/LogicalLocation.h
+++ b/include/lsst/daf/persistence/LogicalLocation.h
@@ -44,7 +44,7 @@
   * @ingroup daf_persistence
   */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 #include "lsst/base.h"
@@ -59,7 +59,7 @@ namespace dafBase = lsst::daf::base;
 
 class LogicalLocation : public dafBase::Citizen {
 public:
-    typedef boost::shared_ptr<LogicalLocation> Ptr;
+    typedef std::shared_ptr<LogicalLocation> Ptr;
 
     LogicalLocation(std::string const& locString,
                     CONST_PTR(dafBase::PropertySet) additionalData = CONST_PTR(dafBase::PropertySet)());

--- a/include/lsst/daf/persistence/Persistence.h
+++ b/include/lsst/daf/persistence/Persistence.h
@@ -47,7 +47,7 @@
   * @ingroup daf_persistence
   */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <map>
 #include <string>
 #include <vector>
@@ -67,7 +67,7 @@ class LogicalLocation;
 
 class Persistence : public lsst::daf::base::Citizen {
 public:
-    typedef boost::shared_ptr<Persistence> Ptr;
+    typedef std::shared_ptr<Persistence> Ptr;
 
     virtual ~Persistence(void);
 

--- a/include/lsst/daf/persistence/Storage.h
+++ b/include/lsst/daf/persistence/Storage.h
@@ -43,7 +43,7 @@
   * @ingroup daf_persistence
   */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <map>
 #include <string>
 #include <typeinfo>
@@ -59,7 +59,7 @@ class LogicalLocation;
 
 class Storage : public lsst::daf::base::Citizen {
 public:
-    typedef boost::shared_ptr<Storage> Ptr;
+    typedef std::shared_ptr<Storage> Ptr;
     typedef std::vector<Ptr> List;
 
     virtual ~Storage(void);

--- a/include/lsst/daf/persistence/StorageRegistry.h
+++ b/include/lsst/daf/persistence/StorageRegistry.h
@@ -43,7 +43,7 @@
   * @ingroup daf_persistence
   */
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <string>
 
 // #include "lsst/daf/base/Citizen.h"

--- a/include/lsst/daf/persistence/XmlStorage.h
+++ b/include/lsst/daf/persistence/XmlStorage.h
@@ -47,7 +47,7 @@
 
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <fstream>
 
 namespace lsst {
@@ -56,7 +56,7 @@ namespace persistence {
 
 class XmlStorage : public Storage {
 public:
-    typedef boost::shared_ptr<XmlStorage> Ptr;
+    typedef std::shared_ptr<XmlStorage> Ptr;
 
     XmlStorage(void);
     virtual ~XmlStorage(void);

--- a/include/lsst/daf/persistence/XmlStorage.h
+++ b/include/lsst/daf/persistence/XmlStorage.h
@@ -43,12 +43,13 @@
   * @ingroup daf_persistence
   */
 
+#include <fstream>
+#include <memory>
+
 #include "lsst/daf/persistence/Storage.h"
 
 #include <boost/archive/xml_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
-#include <memory>
-#include <fstream>
 
 namespace lsst {
 namespace daf {

--- a/include/lsst/daf/persistence/XmlStorage.h
+++ b/include/lsst/daf/persistence/XmlStorage.h
@@ -72,13 +72,13 @@ public:
     virtual boost::archive::xml_iarchive& getIArchive(void);
 
 private:
-    boost::scoped_ptr<std::ofstream> _ostream;
+    std::unique_ptr<std::ofstream> _ostream;
         ///< Underlying output stream.
-    boost::scoped_ptr<std::ifstream> _istream;
+    std::unique_ptr<std::ifstream> _istream;
         ///< Underlying input stream.
-    boost::scoped_ptr<boost::archive::xml_oarchive> _oarchive;
+    std::unique_ptr<boost::archive::xml_oarchive> _oarchive;
         ///< Boost XML output archive.
-    boost::scoped_ptr<boost::archive::xml_iarchive> _iarchive;
+    std::unique_ptr<boost::archive::xml_iarchive> _iarchive;
         ///< Boost XML input archive.
 };
 

--- a/python/lsst/daf/persistence/persistenceLib.i
+++ b/python/lsst/daf/persistence/persistenceLib.i
@@ -63,7 +63,7 @@ Access to the lsst::daf::persistence classes
 %newobject lsst::daf::persistence::Persistence::getRetrieveStorage;
 %newobject lsst::daf::persistence::Persistence::unsafeRetrieve;
 
-%template(StorageList) std::vector<boost::shared_ptr<lsst::daf::persistence::Storage> >;
+%template(StorageList) std::vector<std::shared_ptr<lsst::daf::persistence::Storage> >;
 %template(TableList) std::vector<std::string>;
 
 %include "lsst/daf/persistence/DbAuth.h"

--- a/src/BoostStorage.cc
+++ b/src/BoostStorage.cc
@@ -55,7 +55,7 @@ namespace persistence {
 /** Constructor.
  */
 BoostStorage::BoostStorage(void) : Storage(typeid(*this)),
-    _ostream(0), _istream(0), _oarchive(0), _iarchive(0) {
+    _ostream{}, _istream{}, _oarchive{}, _iarchive{} {
 }
 
 /** Destructor.
@@ -102,10 +102,10 @@ void BoostStorage::startTransaction(void) {
  * No transaction support for now.
  */
 void BoostStorage::endTransaction(void) {
-    _oarchive.reset(0);
-    _ostream.reset(0);
-    _iarchive.reset(0);
-    _istream.reset(0);
+    _oarchive.reset();
+    _ostream.reset();
+    _iarchive.reset();
+    _istream.reset();
 }
 
 /** Get a \c boost::serialization archive suitable for output.

--- a/src/XmlStorage.cc
+++ b/src/XmlStorage.cc
@@ -52,7 +52,7 @@ namespace persistence {
 /** Constructor.
  */
 XmlStorage::XmlStorage(void) : Storage(typeid(*this)),
-    _ostream(0), _istream(0), _oarchive(0), _iarchive(0) {
+    _ostream{}, _istream{}, _oarchive{}, _iarchive{} {
 }
 
 /** Destructor.
@@ -95,10 +95,10 @@ void XmlStorage::startTransaction(void) {
  * No transaction support for now, but close streams.
  */
 void XmlStorage::endTransaction(void) {
-    _oarchive.reset(0);
-    _ostream.reset(0);
-    _iarchive.reset(0);
-    _istream.reset(0);
+    _oarchive.reset();
+    _ostream.reset();
+    _iarchive.reset();
+    _istream.reset();
 }
 
 /** Get a \c boost::serialization XML archive suitable for output.

--- a/tests/Persistence_1.cc
+++ b/tests/Persistence_1.cc
@@ -50,7 +50,7 @@ class MyFormatter;
 
 class MyPersistable : public dafBase::Persistable {
 public:
-    typedef boost::shared_ptr<MyPersistable> Ptr;
+    typedef std::shared_ptr<MyPersistable> Ptr;
     MyPersistable(double ra = 0.0, double decl = 0.0) : _ra(ra), _decl(decl) { };
     double getRa(void) const { return _ra; };
     double getDecl(void) const { return _decl; };
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(PersistenceTest) {
         dafBase::Persistable::Ptr pp = persist->retrieve("MyPersistable", storageList, additionalData);
         BOOST_CHECK(pp != 0);
         BOOST_CHECK(typeid(*pp) == typeid(MyPersistable));
-        MyPersistable::Ptr mp1 = boost::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
+        MyPersistable::Ptr mp1 = std::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
         BOOST_CHECK(mp1);
         BOOST_CHECK(mp1.get() != &mp);
         BOOST_CHECK_EQUAL(mp1->getRa(), 1.73205);
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(PersistenceTest) {
         dafBase::Persistable::Ptr pp = persist->retrieve("MyPersistable", storageList, additionalData);
         BOOST_CHECK(pp);
         BOOST_CHECK(typeid(*pp) == typeid(MyPersistable));
-        MyPersistable::Ptr mp1 = boost::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
+        MyPersistable::Ptr mp1 = std::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
         BOOST_CHECK(mp1);
         BOOST_CHECK(mp1.get() != &mp);
         BOOST_CHECK_EQUAL(mp1->getRa(), 1.73205);
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(PersistenceTest) {
         dafBase::Persistable::Ptr pp = persist->retrieve("MyPersistable", storageList, additionalData);
         BOOST_CHECK(pp);
         BOOST_CHECK(typeid(*pp) == typeid(MyPersistable));
-        MyPersistable::Ptr mp1 = boost::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
+        MyPersistable::Ptr mp1 = std::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
         BOOST_CHECK(mp1);
         BOOST_CHECK(mp1.get() != &mp);
         BOOST_CHECK_EQUAL(mp1->getRa(), 1.73205);

--- a/tests/Persistence_2.cc
+++ b/tests/Persistence_2.cc
@@ -51,7 +51,7 @@ class MyFormatter;
 
 class MyPersistable : public dafBase::Persistable {
 public:
-    typedef boost::shared_ptr<MyPersistable> Ptr;
+    typedef std::shared_ptr<MyPersistable> Ptr;
     MyPersistable(double ra = 0.0, double decl = 0.0) : _ra(ra), _decl(decl) { };
     double getRa(void) const { return _ra; };
     double getDecl(void) const { return _decl; };
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(Persistence2Test) {
         dafBase::Persistable::Ptr pp = persist->retrieve("MyPersistable", storageList, additionalData);
         BOOST_CHECK_MESSAGE(pp != 0, "Didn't get a Persistable");
         BOOST_CHECK_MESSAGE(typeid(*pp) == typeid(MyPersistable), "Didn't get MyPersistable");
-        MyPersistable::Ptr mp1 = boost::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
+        MyPersistable::Ptr mp1 = std::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp);
         BOOST_CHECK_MESSAGE(mp1, "Couldn't cast to MyPersistable");
         BOOST_CHECK_MESSAGE(mp1.get() != &mp, "Got same MyPersistable");
         BOOST_CHECK_MESSAGE(mp1->getRa() == 1.73205, "RA is incorrect");

--- a/tests/Persistence_3.cc
+++ b/tests/Persistence_3.cc
@@ -54,7 +54,7 @@ class MyFormatter;
 
 class MyPersistable : public dafBase::Persistable {
 public:
-    typedef boost::shared_ptr<MyPersistable> Ptr;
+    typedef std::shared_ptr<MyPersistable> Ptr;
     MyPersistable(double ra = 0.0, double decl = 0.0) : _ra(ra), _decl(decl) { };
     double getRa(void) const { return _ra; };
     double getDecl(void) const { return _decl; };
@@ -158,13 +158,13 @@ BOOST_AUTO_TEST_CASE(Persistence3Test) {
         dafBase::Persistable::Ptr pp = persist->retrieve("PropertySet", storageList, additionalData);
         BOOST_CHECK_MESSAGE(pp != 0, "Didn't get a Persistable");
         BOOST_CHECK_MESSAGE(typeid(*pp) == typeid(dafBase::PropertySet), "Didn't get PropertySet");
-        dafBase::PropertySet::Ptr dp = boost::dynamic_pointer_cast<dafBase::PropertySet, dafBase::Persistable>(pp);
+        dafBase::PropertySet::Ptr dp = std::dynamic_pointer_cast<dafBase::PropertySet, dafBase::Persistable>(pp);
         BOOST_CHECK_MESSAGE(dp, "Couldn't cast to PropertySet");
         BOOST_CHECK_MESSAGE(dp != theProperty, "Got same PropertySet");
         dafBase::Persistable::Ptr pp1 = dp->getAsPersistablePtr("prop");
         BOOST_CHECK_MESSAGE(pp1, "Couldn't retrieve Persistable");
         BOOST_CHECK_MESSAGE(typeid(*pp1) == typeid(MyPersistable), "Not a MyPersistable");
-        MyPersistable::Ptr mp = boost::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp1);
+        MyPersistable::Ptr mp = std::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(pp1);
         BOOST_CHECK_MESSAGE(mp, "Couldn't retrieve MyPersistable");
         BOOST_CHECK_MESSAGE(mp->getRa() == 1.73205, "RA is incorrect");
         BOOST_CHECK_MESSAGE(mp->getDecl() == 1.61803, "Decl is incorrect");

--- a/tests/PropertySetPersist.cc
+++ b/tests/PropertySetPersist.cc
@@ -22,12 +22,13 @@
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
  
+#include <memory>
+
 #include <lsst/daf/base/PropertySet.h>
 #include <lsst/daf/base/Citizen.h>
 #include <lsst/pex/logging/Trace.h>
 #include <lsst/utils/Utils.h>
 
-#include <memory>
 #include "lsst/pex/policy/Policy.h"
 #include "lsst/daf/persistence/Persistence.h"
 #include "lsst/daf/persistence/LogicalLocation.h"

--- a/tests/PropertySetPersist.cc
+++ b/tests/PropertySetPersist.cc
@@ -96,10 +96,10 @@ BOOST_AUTO_TEST_CASE(PersistDifferentTypes) {
 
 BOOST_AUTO_TEST_CASE(PersistManyTypes) {
     dafBase::PropertySet::Ptr additionalData =
-        boost::make_shared<dafBase::PropertySet>(); // empty for testing
+        std::make_shared<dafBase::PropertySet>(); // empty for testing
 
     dafBase::PropertySet::Ptr fooProp =
-        boost::make_shared<dafBase::PropertySet>();
+        std::make_shared<dafBase::PropertySet>();
     fooProp->set<char>("char", 'x');
     fooProp->set<signed char>("schar", 'y');
     fooProp->set<unsigned char>("uchar", 'z');
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(PersistManyTypes) {
     fooProp->set("date", now);
 
     lsst::pex::policy::Policy::Ptr policyPtr =
-        boost::make_shared<lsst::pex::policy::Policy>();
+        std::make_shared<lsst::pex::policy::Policy>();
     dafPersist::Persistence::Ptr persist =
         dafPersist::Persistence::getPersistence(policyPtr);
 
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(PersistManyTypes) {
     BOOST_CHECK(pp);
     BOOST_CHECK(typeid(*pp) == typeid(dafBase::PropertySet));
     dafBase::PropertySet::Ptr ps =
-        boost::dynamic_pointer_cast<dafBase::PropertySet,
+        std::dynamic_pointer_cast<dafBase::PropertySet,
                                     dafBase::Persistable>(pp);
     BOOST_CHECK(ps);
     BOOST_CHECK(ps.get() != fooProp.get());
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(PersistManyTypes) {
     pp = persist->retrieve("PropertySet", storageList, additionalData);
     BOOST_CHECK(pp);
     BOOST_CHECK(typeid(*pp) == typeid(dafBase::PropertySet));
-    ps = boost::dynamic_pointer_cast<dafBase::PropertySet,
+    ps = std::dynamic_pointer_cast<dafBase::PropertySet,
                                      dafBase::Persistable>(pp);
     BOOST_CHECK(ps);
     BOOST_CHECK(ps.get() != fooProp.get());

--- a/tests/PropertySetPersist.cc
+++ b/tests/PropertySetPersist.cc
@@ -27,7 +27,7 @@
 #include <lsst/pex/logging/Trace.h>
 #include <lsst/utils/Utils.h>
 
-#include "boost/make_shared.hpp"
+#include <memory>
 #include "lsst/pex/policy/Policy.h"
 #include "lsst/daf/persistence/Persistence.h"
 #include "lsst/daf/persistence/LogicalLocation.h"

--- a/tests/PropertySet_2.cc
+++ b/tests/PropertySet_2.cc
@@ -48,7 +48,7 @@ class MyFormatter;
 
 class MyPersistable : public dafBase::Persistable {
 public:
-    typedef boost::shared_ptr<MyPersistable> Ptr;
+    typedef std::shared_ptr<MyPersistable> Ptr;
     MyPersistable(double ra = 0.0, double decl = 0.0) : _ra(ra), _decl(decl) { };
     double getRa(void) const { return _ra; };
     double getDecl(void) const { return _decl; };
@@ -152,9 +152,9 @@ BOOST_AUTO_TEST_CASE(PropertySet2Test) {
     additionalData->add("visitId", testId);
     additionalData->add("sliceId", 0);
 
-    boost::shared_ptr<MyPersistable> mp(new MyPersistable(1.73205, 1.61803));
+    std::shared_ptr<MyPersistable> mp(new MyPersistable(1.73205, 1.61803));
     dafBase::PropertySet ps;
-    ps.add("mp", boost::static_pointer_cast<dafBase::Persistable, MyPersistable>(mp));
+    ps.add("mp", std::static_pointer_cast<dafBase::Persistable, MyPersistable>(mp));
     ps.add("first.second", 8118);
 
     dafPersist::LogicalLocation pathLoc("tests/data/PropSet.boost." + testIdString);
@@ -175,11 +175,11 @@ BOOST_AUTO_TEST_CASE(PropertySet2Test) {
         dafBase::Persistable::Ptr pp = persist->retrieve("PropertySet", storageList, additionalData);
         BOOST_CHECK(pp != 0);
         BOOST_CHECK(typeid(*pp) == typeid(dafBase::PropertySet));
-        dafBase::PropertySet::Ptr ps1 = boost::dynamic_pointer_cast<dafBase::PropertySet, dafBase::Persistable>(pp);
+        dafBase::PropertySet::Ptr ps1 = std::dynamic_pointer_cast<dafBase::PropertySet, dafBase::Persistable>(pp);
         BOOST_CHECK(ps1);
         BOOST_CHECK(ps1.get() != &ps);
         BOOST_CHECK_EQUAL(ps1->get<int>("first.second"), 8118);
-        boost::shared_ptr<MyPersistable> mp1 = boost::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(ps1->getAsPersistablePtr("mp"));
+        std::shared_ptr<MyPersistable> mp1 = std::dynamic_pointer_cast<MyPersistable, dafBase::Persistable>(ps1->getAsPersistablePtr("mp"));
         BOOST_CHECK(mp1);
         BOOST_CHECK_EQUAL(mp1->getRa(), 1.73205);
         BOOST_CHECK_EQUAL(mp1->getDecl(), 1.61803);


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
