### PR TITLE
DM-8423: Wrap obs_base (was daf_butlerUtils) with pybind11

### DIFF
--- a/python/lsst/daf/persistence/butlerLocation.py
+++ b/python/lsst/daf/persistence/butlerLocation.py
@@ -208,7 +208,8 @@ class ButlerLocation(yaml.YAMLObject):
 
     def __init__(self, pythonType, cppType, storageName, locationList, dataId, mapper, storage=None,
                  usedDataId=None, datasetType=None):
-        self.pythonType = pythonType
+        # pythonType is sometimes unicode with Python 2 and pybind11; this breaks the interpreter
+        self.pythonType = str(pythonType) if isinstance(pythonType, basestring) else pythonType
         self.cppType = cppType
         self.storageName = storageName
         self.mapper = mapper

--- a/python/lsst/daf/persistence/posixStorage.py
+++ b/python/lsst/daf/persistence/posixStorage.py
@@ -290,9 +290,8 @@ class PosixStorage(Storage):
                 storageList = StorageList()
                 storage = self.persistence.getRetrieveStorage(storageName, logLoc)
                 storageList.append(storage)
-                itemData = self.persistence.unsafeRetrieve(
+                finalItem = self.persistence.unsafeRetrieve(
                     butlerLocation.getCppType(), storageList, additionalData)
-                finalItem = pythonType.swigConvert(itemData)
             results.append(finalItem)
 
         return results

--- a/python/lsst/daf/persistence/utils.py
+++ b/python/lsst/daf/persistence/utils.py
@@ -110,7 +110,8 @@ def doImport(pythonType):
         if not isinstance(pythonType, basestring):
             raise TypeError("Unhandled type of pythonType, val:%s" % pythonType)
         # import this pythonType dynamically
-        pythonTypeTokenList = pythonType.split('.')
+        # pythonType is sometimes unicode with Python 2 and pybind11; this breaks the interpreter
+        pythonTypeTokenList = str(pythonType).split('.')
         importClassString = pythonTypeTokenList.pop()
         importClassString = importClassString.strip()
         importPackage = ".".join(pythonTypeTokenList)


### PR DESCRIPTION
This PR makes two changes to the previously wrapped `daf_persistence`. The first is to remove swig-specific Python code that was overlooked before; the second is to compensate for Pybind11's tendency to use `unicode` as its primary string type in Python 2.