### PR TITLE
DM-12450: Support looking only in output repos in datasetExists

### DIFF
--- a/python/lsst/daf/persistence/butlerSubset.py
+++ b/python/lsst/daf/persistence/butlerSubset.py
@@ -263,19 +263,20 @@ class ButlerDataRef(object):
         return self.butlerSubset.butler.subset(self.butlerSubset.datasetType,
                                                level, self.dataId)
 
-    def datasetExists(self, datasetType=None, **rest):
+    def datasetExists(self, datasetType=None, write=False, **rest):
         """
         Determine if a dataset exists of the given type (or the type used when
         creating the ButlerSubset, if None) as specified by the ButlerDataRef.
 
         @param datasetType (str) dataset type to check.
+        @param write (bool) if True, search only in output repositories
         @param **rest            keywords arguments with data identifiers
         @returns bool
         """
         if datasetType is None:
             datasetType = self.butlerSubset.datasetType
         return self.butlerSubset.butler.datasetExists(
-            datasetType, self.dataId, **rest)
+            datasetType, self.dataId, write=write, **rest)
 
     def getButler(self):
         """


### PR DESCRIPTION
This adds a `write` option to `datasetExists`, which causes it to only look in locations where datasets would be written.