### PR TITLE
DM-10319: _filename functions return first mappable repository even when file does not exist

### DIFF
--- a/python/lsst/daf/persistence/butler.py
+++ b/python/lsst/daf/persistence/butler.py
@@ -1573,8 +1573,6 @@ class Butler(object):
             # Return the first valid write location.
             for location in locations:
                 if isinstance(location, ButlerComposite):
-                    disassembler = location.disassembler if location.disassembler else genericDisassembler
-                    disassembler(obj=obj, dataId=location.dataId, componentInfo=location.componentInfo)
                     for name, info in location.componentInfo.items():
                         if not info.inputOnly:
                             return self.getUri(info.datasetType, location.dataId, write=True)

--- a/python/lsst/daf/persistence/butler.py
+++ b/python/lsst/daf/persistence/butler.py
@@ -1580,10 +1580,11 @@ class Butler(object):
                             return self.getUri(info.datasetType, location.dataId, write=True)
                 else:
                     return location.getLocationsWithRoot()[0]
-            return locs
+            # fall back to raise
+            raise NoResults("No locations for getUri(write=True): ", datasetType, dataId)
         else:
             # Follow the read path, only return the first valid read
-            return location.getLocationsWithRoot()[0]
+            return locations.getLocationsWithRoot()[0]
 
     def _read(self, location):
         """Unpersist an object using data inside a ButlerLocation or ButlerComposite object.

--- a/python/lsst/daf/persistence/butler.py
+++ b/python/lsst/daf/persistence/butler.py
@@ -1536,6 +1536,39 @@ class Butler(object):
                                (str(datasetType), str(level), str(dataId), str(rest)))
         return ButlerDataRef(subset, subset.cache[0])
 
+    def getUri(self, datasetType, dataId=None, write=False, **rest):
+        """Return the URI for a dataset
+
+        .. warning:: This is intended only for debugging. The URI should
+        never be used for anything other than printing.
+
+        .. note:: In the event there are multiple URIs, we return only
+        the first.
+
+        Parameters
+        ----------
+        datasetType : `str`
+           The dataset type of interest.
+        dataId : `dict`, optional
+           The data identifier.
+        write : `bool`, optional
+           Return the URI for writing?
+        rest : `dict`, optional
+           Keyword arguments for the data id.
+
+        Returns
+        -------
+        uri : `str`
+           URI for dataset.
+        """
+        datasetType = self._resolveDatasetTypeAlias(datasetType)
+        dataId = DataId(dataId)
+        dataId.update(**rest)
+        location = self._locate(datasetType, dataId, write=write)
+        if location is None:
+            raise NoResults("No locations for getUri: ", datasetType, dataId)
+        return location.getLocationsWithRoot()[0]
+
     def _read(self, location):
         """Unpersist an object using data inside a ButlerLocation or ButlerComposite object.
 

--- a/python/lsst/daf/persistence/butler.py
+++ b/python/lsst/daf/persistence/butler.py
@@ -1545,6 +1545,8 @@ class Butler(object):
         .. note:: In the event there are multiple URIs for read, we return only
         the first.
 
+        .. note:: getUri() does not currently support composite datasets.
+
         Parameters
         ----------
         datasetType : `str`

--- a/python/lsst/daf/persistence/butlerSubset.py
+++ b/python/lsst/daf/persistence/butlerSubset.py
@@ -224,6 +224,8 @@ class ButlerDataRef(object):
         .. note:: In the event there are multiple URIs, we return only
         the first.
 
+        .. note:: getUri() does not currently support composite datasets.
+
         Parameters
         ----------
         datasetType : `str`, optional

--- a/python/lsst/daf/persistence/butlerSubset.py
+++ b/python/lsst/daf/persistence/butlerSubset.py
@@ -215,6 +215,34 @@ class ButlerDataRef(object):
             datasetType = self.butlerSubset.datasetType
         self.butlerSubset.butler.put(obj, datasetType, self.dataId, doBackup=doBackup, **rest)
 
+    def getUri(self, datasetType=None, write=False, **rest):
+        """Return the URL for a dataset
+
+        .. warning:: This is intended only for debugging. The URI should
+        never be used for anything other than printing.
+
+        .. note:: In the event there are multiple URIs, we return only
+        the first.
+
+        Parameters
+        ----------
+        datasetType : `str`, optional
+           The dataset type of interest.
+        write : `bool`, optional
+           Return the URI for writing?
+        rest : `dict`, optional
+           Keyword arguments for the data id.
+
+        Returns
+        -------
+        uri : `str`
+           URI for dataset
+        """
+
+        if datasetType is None:
+            datasetType = self.butlerSubset.datasetType
+        return self.butlerSubset.butler.getUri(datasetType, self.dataId, write=write, **rest)
+
     def subLevels(self):
         """
         Return a list of the lower levels of the hierarchy than this

--- a/tests/test_butlerSubset.py
+++ b/tests/test_butlerSubset.py
@@ -144,6 +144,12 @@ class ButlerSubsetTestCase(unittest.TestCase):
             self.assertEqual(type(image), list)
             self.assertEqual(image, inputList)
 
+            # Tests for new getUri
+            imageUri = iterator.getUri(self.calexpTypeName)
+            fileName = 'calexp_v%(visit)d_R%(raft)s_S%(sensor)s.pickle' % iterator.dataId
+            self.assertEqual(imageUri, os.path.join(self.tmpRoot, fileName))
+            self.assertEqual(os.path.isfile(imageUri), True)
+
         for fileName in inputList:
             os.unlink(os.path.join(self.tmpRoot, fileName))
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -10,7 +10,7 @@
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.1n
+# (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -178,6 +178,12 @@ class TestBasics(unittest.TestCase):
                          os.path.join(ROOT, 'butlerAlias', 'data', 'input', 'raw', 'raw_v2_fg.fits.gz'))
         self.assertEqual(os.path.isfile(raw_uri), True)
 
+    def testGetUriWrite(self):
+        raw_uri = self.butler.getUri('src', {'visit': '9', 'filter': 'g'}, write=True)
+        self.assertEqual(raw_uri,
+                         os.path.join(self.testDir, 'repoA', 'raw', 'raw_v9_fg.fits'))
+        self.assertEqual(os.path.isfile(raw_uri), False)
+
     def testSubset(self):
         subset = self.butler.subset('raw')
         self.assertEqual(len(subset), 3)

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -179,9 +179,9 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(os.path.isfile(raw_uri), True)
 
     def testGetUriWrite(self):
-        raw_uri = self.butler.getUri('src', {'visit': '9', 'filter': 'g'}, write=True)
+        raw_uri = self.butler.getUri('raw', {'visit': '9', 'filter': 'g'}, write=True)
         self.assertEqual(raw_uri,
-                         os.path.join(self.testDir, 'repoA', 'raw', 'raw_v9_fg.fits'))
+                         os.path.join(self.testDir, 'repoA', 'raw', 'raw_v9_fg.fits.gz'))
         self.assertEqual(os.path.isfile(raw_uri), False)
 
     def testSubset(self):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -10,7 +10,7 @@
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# (at your option) any later version.1n
 #
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -171,6 +171,12 @@ class TestBasics(unittest.TestCase):
         raw_image = self.butler.get('raw', {'visit': '2', 'filter': 'g'})
         # in this case the width is known to be 1026:
         self.assertEqual(raw_image[1].header["NAXIS1"], 1026)
+
+    def testGetUri(self):
+        raw_uri = self.butler.getUri('raw', {'visit': '2', 'filter': 'g'})
+        self.assertEqual(raw_uri,
+                         os.path.join(ROOT, 'butlerAlias', 'data', 'input', 'raw', 'raw_v2_fg.fits.gz'))
+        self.assertEqual(os.path.isfile(raw_uri), True)
 
     def testSubset(self):
         subset = self.butler.subset('raw')


### PR DESCRIPTION
As discussed on JIRA, this implementation sidesteps the _filename magic entirely and adds a new getUri(write=write) method for debugging that retrieves the actual filename that the butler will use.  This is what developers expect.