### PR TITLE
Catch only NoResults and IOError exceptions.

### DIFF
--- a/python/lsst/daf/persistence/butler.py
+++ b/python/lsst/daf/persistence/butler.py
@@ -1350,14 +1350,14 @@ class Butler(object):
                     # exists in storage, because the bypass function may not actually use the location
                     # according to the template. Instead, execute the bypass function and include its results
                     # in the bypass attribute of the location. The bypass function may fail for any reason,
-                    # the most common case being that a file does not exist. If it raises an exception we
-                    # ignore its existance and proceed as though it does not exist.
+                    # the most common case being that a file does not exist. If it raises an exception
+                    # indicating such, we ignore the bypass function and proceed as though it does not exist.
                     if hasattr(location.mapper, "bypass_" + location.datasetType):
                         bypass = self._getBypassFunc(location, dataId)
                         try:
                             bypass = bypass()
                             location.bypass = bypass
-                        except Exception:
+                        except (NoResults, IOError):
                             pass
                     # If a location was found but the location does not exist, keep looking in input
                     # repositories (the registry may have had enough data for a lookup even thought the object

--- a/python/lsst/daf/persistence/butler.py
+++ b/python/lsst/daf/persistence/butler.py
@@ -1358,7 +1358,9 @@ class Butler(object):
                             bypass = bypass()
                             location.bypass = bypass
                         except (NoResults, IOError):
-                            pass
+                            self.log.info("NoResults or IOError (continuing search) while evaluating "
+                                          "bypass function for Dataset type:{} Data ID:{} at "
+                                          "location {}".format(datasetType, dataId, location))
                     # If a location was found but the location does not exist, keep looking in input
                     # repositories (the registry may have had enough data for a lookup even thought the object
                     # exists in a different repository.)


### PR DESCRIPTION
Bypass function handling was trapping all exceptions, but most of them are actually errors that should be reported.