### PR TITLE
DM-13876: Implement and register ParquetStorage as a butler storage type

### DIFF
--- a/python/lsst/daf/persistence/posixStorage.py
+++ b/python/lsst/daf/persistence/posixStorage.py
@@ -617,8 +617,8 @@ def readParquetStorage(butlerLocation):
 
     The object returned by this is expected to be a subtype
     of `ParquetTable`, which is a thin wrapper to `pyarrow.ParquetFile`
-    that allows for lazy loading of the data.  This is notably 
-    a different object from what gets passed to the butler `put` function, 
+    that allows for lazy loading of the data.  This is notably
+    a different object from what gets passed to the butler `put` function,
     which should be a `pandas.DataFrame`.
 
     Parameters

--- a/python/lsst/daf/persistence/posixStorage.py
+++ b/python/lsst/daf/persistence/posixStorage.py
@@ -288,7 +288,7 @@ class PosixStorage(StorageInterface):
         raise(RuntimeError("No formatter for location:{}".format(butlerLocation)))
 
     def butlerLocationExists(self, location):
-        """Implementaion of PosixStorage.exists for ButlerLocation objects.
+        """Implementation of PosixStorage.exists for ButlerLocation objects.
         """
         storageName = location.getStorageName()
         if storageName not in ('BoostStorage', 'FitsStorage', 'PafStorage',
@@ -617,9 +617,7 @@ def readParquetStorage(butlerLocation):
 
     The object returned by this is expected to be a subtype
     of `ParquetTable`, which is a thin wrapper to `pyarrow.ParquetFile`
-    that allows for lazy loading of the data.  This is notably
-    a different object from what gets passed to the butler `put` function,
-    which should be a `pandas.DataFrame`.
+    that allows for lazy loading of the data.  
 
     Parameters
     ----------
@@ -650,22 +648,22 @@ def readParquetStorage(butlerLocation):
         # pythonType will be ParquetTable (or perhaps MultilevelParquetTable)
         #  filename should be the first kwarg, but being explicit here.
         results.append(pythonType(filename=filename))
-    return results
+
+    if len(results) > 1:
+        Log.getLogger("daf.persistence.butler").warning('Not using multiple locations!')
+
+    return results[0]
 
 
 def writeParquetStorage(butlerLocation, obj):
     """Writes pandas dataframe to parquet file
 
-    Note, this takes a `pandas.DataFrame` to write, whereas
-    `readParquetStorage` returns a wrapper to `pyarrow.ParquetFile`
-    that allows for lazy loading of the on-disk data.
-
     Parameters
     ----------
     butlerLocation : ButlerLocation
         The location & formatting for the object(s) to be read.
-    obj : `pandas.DataFrame`
-        DataFrame to write.
+    obj : `lsst.qa.explorer.parquetTable.ParquetTable`
+        Wrapped DataFrame to write.
 
     """
     additionalData = butlerLocation.getAdditionalData()

--- a/python/lsst/daf/persistence/posixStorage.py
+++ b/python/lsst/daf/persistence/posixStorage.py
@@ -288,10 +288,12 @@ class PosixStorage(StorageInterface):
         raise(RuntimeError("No formatter for location:{}".format(butlerLocation)))
 
     def butlerLocationExists(self, location):
-        """Implementaion of PosixStorage.exists for ButlerLocation objects."""
+        """Implementaion of PosixStorage.exists for ButlerLocation objects.
+        """
         storageName = location.getStorageName()
         if storageName not in ('BoostStorage', 'FitsStorage', 'PafStorage',
-                               'PickleStorage', 'ConfigStorage', 'FitsCatalogStorage'):
+                               'PickleStorage', 'ConfigStorage', 'FitsCatalogStorage',
+                               'ParquetStorage'):
             self.log.warn("butlerLocationExists for non-supported storage %s" % location)
             return False
         for locationString in location.getLocations():
@@ -610,6 +612,70 @@ def writeFitsStorage(butlerLocation, obj):
             persistence.persist(obj, storageList, butlerLocation.getAdditionalData())
 
 
+def readParquetStorage(butlerLocation):
+    """Read from a butlerLocation.
+
+    The object returned by this is expected to be a subtype
+    of `ParquetTable`, which is a thin wrapper to `pyarrow.ParquetFile`
+    that allows for lazy loading of the data.  This is notably 
+    a different object from what gets passed to the butler `put` function, 
+    which should be a `pandas.DataFrame`.
+
+    Parameters
+    ----------
+    butlerLocation : ButlerLocation
+        The location & formatting for the object(s) to be read.
+
+    Returns
+    -------
+    A list of objects as described by the butler location. One item for
+    each location in butlerLocation.getLocations()
+    """
+    results = []
+    additionalData = butlerLocation.getAdditionalData()
+
+    for locationString in butlerLocation.getLocations():
+        locStringWithRoot = os.path.join(butlerLocation.getStorage().root, locationString)
+        logLoc = LogicalLocation(locStringWithRoot, additionalData)
+        if not os.path.exists(logLoc.locString()):
+            raise RuntimeError("No such parquet file: " + logLoc.locString())
+
+        pythonType = butlerLocation.getPythonType()
+        if pythonType is not None:
+            if isinstance(pythonType, basestring):
+                pythonType = doImport(pythonType)
+
+        filename = logLoc.locString()
+
+        # pythonType will be ParquetTable (or perhaps MultilevelParquetTable)
+        #  filename should be the first kwarg, but being explicit here.
+        results.append(pythonType(filename=filename))
+    return results
+
+
+def writeParquetStorage(butlerLocation, obj):
+    """Writes pandas dataframe to parquet file
+
+    Note, this takes a `pandas.DataFrame` to write, whereas
+    `readParquetStorage` returns a wrapper to `pyarrow.ParquetFile`
+    that allows for lazy loading of the on-disk data.
+
+    Parameters
+    ----------
+    butlerLocation : ButlerLocation
+        The location & formatting for the object(s) to be read.
+    obj : `pandas.DataFrame`
+        DataFrame to write.
+
+    """
+    additionalData = butlerLocation.getAdditionalData()
+    locations = butlerLocation.getLocations()
+    with SafeFilename(os.path.join(butlerLocation.getStorage().root, locations[0])) as locationString:
+        logLoc = LogicalLocation(locationString, additionalData)
+        filename = logLoc.locString()
+        obj.write(filename)
+
+
 def readPickleStorage(butlerLocation):
     """Read from a butlerLocation.
 
@@ -796,6 +862,7 @@ def writeBoostStorage(butlerLocation, obj):
 
 
 PosixStorage.registerFormatters("FitsStorage", readFitsStorage, writeFitsStorage)
+PosixStorage.registerFormatters("ParquetStorage", readParquetStorage, writeParquetStorage)
 PosixStorage.registerFormatters("ConfigStorage", readConfigStorage, writeConfigStorage)
 PosixStorage.registerFormatters("PickleStorage", readPickleStorage, writePickleStorage)
 PosixStorage.registerFormatters("FitsCatalogStorage", readFitsCatalogStorage, writeFitsCatalogStorage)


### PR DESCRIPTION
This defines readParquetStorage and writeParquetStorage to define
butler get/put operations for ParquetStorage datatypes.  They use
the wrapper object ParquetTable around pyarrow read/write operations.
Read returns a lazy object; meaning no data is loaded, but arbitrary
columns can be loaded later using the .to_df method of the ParquetTable.
