### PR TITLE
Return list rather than first item; butler needs this.

### DIFF
--- a/python/lsst/daf/persistence/posixStorage.py
+++ b/python/lsst/daf/persistence/posixStorage.py
@@ -652,7 +652,7 @@ def readParquetStorage(butlerLocation):
     if len(results) > 1:
         Log.getLogger("daf.persistence.butler").warning('Not using multiple locations!')
 
-    return results[0]
+    return results
 
 
 def writeParquetStorage(butlerLocation, obj):

--- a/python/lsst/daf/persistence/posixStorage.py
+++ b/python/lsst/daf/persistence/posixStorage.py
@@ -649,9 +649,6 @@ def readParquetStorage(butlerLocation):
         #  filename should be the first kwarg, but being explicit here.
         results.append(pythonType(filename=filename))
 
-    if len(results) > 1:
-        Log.getLogger("daf.persistence.butler").warning('Not using multiple locations!')
-
     return results
 
 


### PR DESCRIPTION
DM-13876 introduced a bug to the `readParquet` so that it no longer works, because it's returning a `ParquetTable` instead of a list, which is expected further on in the butler.  This corrects this.