### PR TITLE
DM-14356: Add matplotlib.figure.Figure storage to PosixStorage.

### DIFF
--- a/python/lsst/daf/persistence/posixStorage.py
+++ b/python/lsst/daf/persistence/posixStorage.py
@@ -777,7 +777,6 @@ def writeFitsCatalogStorage(butlerLocation, obj):
         else:
             kwds = {}
         obj.writeFits(logLoc.locString(), **kwds)
-        return
 
 
 def readMatplotlibStorage(butlerLocation):


### PR DESCRIPTION
Matplotlib figures cannot be retrieved using the butler, but 'put' should now work.

Note that this storage actually only requires that the object being saved have a `savefig` method with the same behavior as matplotlib's.