### PR TITLE
DM-28623: Add explicit initialization of super-class.

### DIFF
--- a/python/lsst/daf/persistence/readProxy.py
+++ b/python/lsst/daf/persistence/readProxy.py
@@ -38,6 +38,7 @@ class ReadProxy(ReadProxyBase):
     __slots__ = ('__cache__', '__callback__')
 
     def __init__(self, func):
+        ReadProxyBase.__init__(self)
         set_callback(self, func)
 
     def __getattr__(self, attr):


### PR DESCRIPTION
This missing call will make `daf_persistence` `pybind11=2.6` compliant.