### PR TITLE
Enable reading polymorphic pex_config types (DM-32062)

### DIFF
--- a/ups/daf_persistence.table
+++ b/ups/daf_persistence.table
@@ -1,6 +1,7 @@
 setupRequired(utils)
 setupRequired(log)
 setupRequired(daf_base)
+setupRequired(pex_config)
 
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)
 envPrepend(DYLD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
The `readConfigStorage()` method now uses special Config method which
can read arbitrary types from serialized data. We still limit allowed
types to the sub-classes of the type defined in policy.